### PR TITLE
Request details in exceptions

### DIFF
--- a/tusclient/exceptions.py
+++ b/tusclient/exceptions.py
@@ -3,12 +3,19 @@ Global Tusclient exception and warning classes.
 """
 
 
-class TusUploadFailed(Exception):
+class TusException(Exception):
+    def __init__(self, message='', status_code=400, response_content=''):
+        super(TusException, self).__init__(message)
+        self.status_code = status_code
+        self.response_content = response_content
+
+
+class TusUploadFailed(TusException):
     """Should be raised when an attempted upload fails"""
     pass
 
 
-class TusCommunicationError(Exception):
+class TusCommunicationError(TusException):
     """
     Should be raised when communications with tus-server behaves
     unexpectedly.

--- a/tusclient/exceptions.py
+++ b/tusclient/exceptions.py
@@ -4,6 +4,21 @@ Global Tusclient exception and warning classes.
 
 
 class TusException(Exception):
+    """
+    Base exception class for Tus-related errors
+
+    :Attributes:
+        - message (str):
+            Main message of the exception
+        - status_code (int):
+            Status code of response indicating an error
+        - response_content (str):
+            Content of response indicating an error
+    :Constructor Args:
+        - message (Optional[str])
+        - status_code (Optional[int])
+        - response_content (Optional[str])
+    """
     def __init__(self, message='', status_code=400, response_content=''):
         super(TusException, self).__init__(message)
         self.status_code = status_code

--- a/tusclient/exceptions.py
+++ b/tusclient/exceptions.py
@@ -6,6 +6,12 @@ Global Tusclient exception and warning classes.
 class TusException(Exception):
     """
     Base exception class for Tus-related errors
+    """
+
+class TusCommunicationError(TusException):
+    """
+    Should be raised when communications with tus-server behaves
+    unexpectedly.
 
     :Attributes:
         - message (str):
@@ -19,20 +25,12 @@ class TusException(Exception):
         - status_code (Optional[int])
         - response_content (Optional[str])
     """
-    def __init__(self, message='', status_code=400, response_content=''):
+    def __init__(self, message, status_code, response_content):
         super(TusException, self).__init__(message)
         self.status_code = status_code
         self.response_content = response_content
 
 
-class TusUploadFailed(TusException):
+class TusUploadFailed(TusCommunicationError):
     """Should be raised when an attempted upload fails"""
-    pass
-
-
-class TusCommunicationError(TusException):
-    """
-    Should be raised when communications with tus-server behaves
-    unexpectedly.
-    """
     pass

--- a/tusclient/uploader.py
+++ b/tusclient/uploader.py
@@ -103,7 +103,7 @@ class Uploader(object):
         offset = resp.headers.get('upload-offset')
         if offset is None:
             msg = 'Attemp to retrieve offset fails with status {}'.format(resp.status_code)
-            raise TusCommunicationError(msg)
+            raise TusCommunicationError(msg, resp.status_code, resp.content)
         return int(offset)
 
     def encode_metadata(self):
@@ -136,7 +136,7 @@ class Uploader(object):
         url = resp.headers.get("location")
         if url is None:
             msg = 'Attemp to retrieve create file url with status {}'.format(resp.status_code)
-            raise TusCommunicationError(msg)
+            raise TusCommunicationError(msg, resp.status_code, resp.content)
         return url
 
     @property
@@ -155,7 +155,7 @@ class Uploader(object):
         if self.request.status_code == 204:
             return True
         else:
-            raise TusUploadFailed
+            raise TusUploadFailed('', self.request.status_code, self.request.response_content)
 
     def get_file_stream(self):
         """


### PR DESCRIPTION
I can examine `uploader.request.response_content` type to retrieve information from response in case of ` tusclient.exceptions.TusUploadFailed`. However, if creation of uploader fails from ` tusclient.exceptions.TusCommunicationError` I cannot determine why. Moreover, accessing properties of exception in case of an error is easier than looking into `request` property. I want to use:

```
class SomeUnitTest(unittest.TestCase):
    # ...
    def test_something(self):
        # ...
        try:
            tus_client = tusclient.client.TusClient(myurl)
            uploader = my_client.uploader(path, chunk_size=512*1024)
        except tusclient.exceptions.TusCommunicationError as e:
            self.assertEqual(e.response_content,  'MyErrorMessage')
            self.assertEqual(e.status_code,  400)

        # ...

        try:
            uploader.upload()
        except tusclient.exceptions.TusUploadFailed as e:
            self.assertEqual(e.response_content,  'MyErrorMessage')
            self.assertEqual(e.status_code,  400)
```