### PR TITLE
Prevent "no curl handle" exception

### DIFF
--- a/tusclient/request.py
+++ b/tusclient/request.py
@@ -22,6 +22,7 @@ class TusRequest(object):
         self.handle = pycurl.Curl()
         self.response_headers = {}
         self.output = six.StringIO()
+        self._status_code = None
 
         self.handle.setopt(pycurl.URL, uploader.url)
         self.handle.setopt(pycurl.HEADERFUNCTION, self._prepare_response_header)
@@ -55,7 +56,7 @@ class TusRequest(object):
         """
         Return request status code.
         """
-        return self.handle.getinfo(pycurl.RESPONSE_CODE)
+        return self._status_code
 
     @property
     def response_content(self):
@@ -69,6 +70,7 @@ class TusRequest(object):
         Perform actual request.
         """
         self.handle.perform()
+        self._status_code = self.handle.getinfo(pycurl.RESPONSE_CODE)
 
     def close(self):
         """


### PR DESCRIPTION
Sometimes after I try to examine HTTP return code after finishing an upload I get following exception:

```
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/test/upload.py", line 301, in test_upload
    self.assertTrue(uploader.verify_upload())
  File "/home/maoba/.virtualenvs/csp2/local/lib/python2.7/site-packages/tusclient/uploader.py", line 155, in verify_upload
    if self.request.status_code == 204:
  File "/home/maoba/.virtualenvs/csp2/local/lib/python2.7/site-packages/tusclient/request.py", line 58, in status_code
    return self.handle.getinfo(pycurl.RESPONSE_CODE)
error: cannot invoke getinfo() - no curl handle
----------------------------------------------------------------------
```
I believe this might be caused by trying to retrieve status code from pycurl handle that's already closed. Proposed change ensures status code is stored immediately after any request, so there's no problem in reading it even if handle is closed prematurely.
