### PR TITLE
Don't Pin Requests to an Old Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ Pygments==2.1.3
 pytest==3.0.3
 pytest-cov==2.3.1
 pytz==2016.7
-requests==2.11.1
+requests>=2.11.1
 responses==0.5.1
 six==1.10.0
 snowballstemmer==1.2.1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
     install_requires = ['requests==2.11.1', 'six==1.10.0', ]
 else:
-    install_requires = ['pycurl==7.43.0', 'requests==2.11.1', 'six==1.10.0']
+    install_requires = ['pycurl==7.43.0', 'requests>=2.11.1', 'six==1.10.0']
 
 PY_VERSION = sys.version_info[0], sys.version_info[1]
 if PY_VERSION < (3, 0):


### PR DESCRIPTION
Requests is currently pinned to an old specific version, it should be updated to be pinned at higher versions to prevent dependency resolution problems. 