### PR TITLE
catch EnvironmentError exceptions in the perform function of tusclient.request.TusRequest

### DIFF
--- a/tusclient/request.py
+++ b/tusclient/request.py
@@ -1,4 +1,5 @@
 import http.client
+import errno
 from future.moves.urllib.parse import urlparse
 
 from tusclient.exceptions import TusUploadFailed
@@ -60,8 +61,14 @@ class TusRequest(object):
             self._response = self.handle.getresponse()
             self.status_code = self._response.status
             self.response_headers = {k.lower(): v for k, v in self._response.getheaders()}
-        except (http.client.HTTPException, EnvironmentError) as e:
+        except http.client.HTTPException as e:
             raise TusUploadFailed(e)
+        # wrap connection related errors not raised by the http.client.HTTP(S)Connection
+        # as TusUploadFailed exceptions to enable retries
+        except OSError as e:
+            if e.errno in (errno.EPIPE, errno.ESHUTDOWN, errno.ECONNABORTED, errno.ECONNREFUSED, errno.ECONNRESET):
+                raise TusUploadFailed(e)
+            raise e
 
     def close(self):
         """

--- a/tusclient/request.py
+++ b/tusclient/request.py
@@ -60,7 +60,7 @@ class TusRequest(object):
             self._response = self.handle.getresponse()
             self.status_code = self._response.status
             self.response_headers = {k.lower(): v for k, v in self._response.getheaders()}
-        except http.client.HTTPException as e:
+        except (http.client.HTTPException, EnvironmentError) as e:
             raise TusUploadFailed(e)
 
     def close(self):


### PR DESCRIPTION
Currently the retry logic of [`tusclient.uploader.Uploader`](https://github.com/bgardiner/tus-py-client/blob/master/tusclient/uploader.py#L282-L293) does not account for all possible exceptions from `self.request.perform()`.  For example, a [`ConnectionError`](https://docs.python.org/3/library/exceptions.html#ConnectionError) can be returned, which is not caught by the exiting [line](https://github.com/tus/tus-py-client/blob/master/tusclient/request.py#L63):
```python
...
except http.client.HTTPException as e:
    raise TusUploadFailed(e)
```
Accordingly, a `TusUploadFailed` exception is not returned and no retries occur. I was able to produce this behavior by restarting the tusd server in the middle of an upload, and no retries were attempted even though the `tusclient.uploader.Uploader` was created with `retries=2`

I propose wrapping all `EnvironmentError` exceptions as `TusUploadFailed` exceptions to correct the retry behavior.  `EnvironmentError` is the most specific I could come up with to achieve desired functionality and still maintain python 2 and 3 compatibility (which appears to be an objective of the package).