### PR TITLE
Make long description render correctly on pypi.org

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     author_email='ifedapoolarewaju@gmail.com',
     description='A Python client for the tus resumable upload protocol ->  http://tus.io',
     long_description=(long_description),
+    long_description_content_type='text/markdown',
     packages=['tusclient', 'tusclient.fingerprint', 'tusclient.storage'],
     include_package_data=True,
     platforms='any',


### PR DESCRIPTION
Use the new `long_description_content_type` keyword argument to mark the long description as being in Markdown.

See this blog post: https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi

This fixes the ugly rendering of the description of this package on https://pypi.org/project/tuspy/