### PR TITLE
automate deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,26 @@ install:
     - "pip install -r requirements.txt"
 script: 
     - "py.test --cov=tusclient"
+deploy:
+    - provider: releases
+      tag: $TRAVIS_TAG
+      api_key: $GITHUB_TOKEN
+      file_glob: true
+      file: "dist/*"
+      skip_cleanup: true
+      draft: false
+      prerelease: true
+      on: 
+        tags: true
+        branch: production
+    - provider: pypi
+      user: <USERNAME>
+      password:
+        secure: <ENCRYPTED_PASSWORD>
+      distributions: sdist bdist_wheel
+      draft: false
+      prerelease: true
+      on:
+        tags: true
+        branch: production
+    


### PR DESCRIPTION
hey, 
attempts to address #10 
not really sure what sort of strategy you specifically want here, just added the settings ive used for other projects
- you'll need to add a user/password for pypi and an api key for github releases
-  i set it to prerelease since the current version number is 0.2.2