### PR TITLE
use requests library everywhere

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -17,13 +17,13 @@ class TusRequestTest(mixin.Mixin):
             self.request.perform()
         with open('LICENSE', 'rb') as f:
             headers = {
-                'upload-offset': 0,
+                'upload-offset': '0',
                 'Content-Type': 'application/offset+octet-stream'
             }
             headers.update(self.uploader.headers)
-            mock_.request.assert_called_with(
-                'PATCH', '/files/15acd89eabdf5738ffc',
-                f.read(), headers)
+            mock_.patch.assert_called_with(
+                'http://master.tus.io/files/15acd89eabdf5738ffc',
+                data=f.read(), headers=headers)
 
     def test_perform_checksum(self):
         self.uploader.upload_checksum = True
@@ -34,15 +34,15 @@ class TusRequestTest(mixin.Mixin):
         with open('LICENSE', 'rb') as f:
             license = f.read()
             headers = {
-                'upload-offset': 0,
+                'upload-offset': '0',
                 'Content-Type': 'application/offset+octet-stream'
             }
             headers.update(self.uploader.headers)
             headers["upload-checksum"] = "sha1 " + \
                 base64.standard_b64encode(hashlib.sha1(license).digest()).decode("ascii")
-            mock_.request.assert_called_with(
-                'PATCH', '/files/15acd89eabdf5738ffc',
-                license, headers)
+            mock_.patch.assert_called_with(
+                'http://master.tus.io/files/15acd89eabdf5738ffc',
+                data=license, headers=headers)
 
     def test_close(self):
         with mock.patch.object(self.request, 'handle') as mock_:

--- a/tusclient/request.py
+++ b/tusclient/request.py
@@ -1,7 +1,6 @@
-import http.client
 import errno
 import base64
-from future.moves.urllib.parse import urlparse
+import requests
 
 from tusclient.exceptions import TusUploadFailed
 
@@ -16,19 +15,15 @@ class TusRequest(object):
     on instantiation.
 
     :Attributes:
-        - handle (<http.client.HTTPConnection>)
+        - handle (<requests.Session>)
         - response_headers (dict)
         - file (file):
             The file that is being uploaded.
     """
 
     def __init__(self, uploader):
-        url = urlparse(uploader.url)
-        if url.scheme == 'https':
-            self.handle = http.client.HTTPSConnection(url.hostname, url.port)
-        else:
-            self.handle = http.client.HTTPConnection(url.hostname, url.port)
-        self._url = url
+        self.handle = requests.Session()
+        self._url = uploader.url
 
         self.response_headers = {}
         self.status_code = None
@@ -36,7 +31,7 @@ class TusRequest(object):
         self.file.seek(uploader.offset)
 
         self._request_headers = {
-            'upload-offset': uploader.offset,
+            'upload-offset': str(uploader.offset),
             'Content-Type': 'application/offset+octet-stream'
         }
         self._request_headers.update(uploader.headers)
@@ -51,16 +46,13 @@ class TusRequest(object):
         """
         Return response data
         """
-        return self._response.read()
+        return self._response.content
 
     def perform(self):
         """
         Perform actual request.
         """
         try:
-            host = '{}://{}'.format(self._url.scheme, self._url.netloc)
-            path = self._url.geturl().replace(host, '', 1)
-
             chunk = self.file.read(self._content_length)
             if self._upload_checksum:
                 self._request_headers["upload-checksum"] = \
@@ -70,18 +62,11 @@ class TusRequest(object):
                             self._checksum_algorithm(chunk).digest()
                         ).decode("ascii"),
                     ))
-            self.handle.request("PATCH", path, chunk, self._request_headers)
-            self._response = self.handle.getresponse()
-            self.status_code = self._response.status
-            self.response_headers = {k.lower(): v for k, v in self._response.getheaders()}
-        except http.client.HTTPException as e:
+            self._response = self.handle.patch(self._url, data=chunk, headers=self._request_headers)
+            self.status_code = self._response.status_code
+            self.response_headers = {k.lower(): v for k, v in self._response.headers.items()}
+        except requests.exceptions.RequestException as e:
             raise TusUploadFailed(e)
-        # wrap connection related errors not raised by the http.client.HTTP(S)Connection
-        # as TusUploadFailed exceptions to enable retries
-        except OSError as e:
-            if e.errno in (errno.EPIPE, errno.ESHUTDOWN, errno.ECONNABORTED, errno.ECONNREFUSED, errno.ECONNRESET):
-                raise TusUploadFailed(e)
-            raise e
 
     def close(self):
         """


### PR DESCRIPTION
I have ported the use of `http.client` in `request.py` to the requests library.

We have experienced an issue with the tus client behind a proxy, where the client was unable to upload the chunks to the server. Investigating the issue reviled, that the use of `http.client` was not supporting proxy settings.

Since all the other requests to the server have been done using the requests library, I would like to propose to do the same for `request.py`  and thus get all the proxy support for free.

NOTE: Since `handle` in `TusRequest` is a public member, this change might break code that uses the  handle directly.