### PR TITLE
drop python 2 + async upload

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,561 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,googleapiclient.discovery.Resource
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=google.cloud.vision_v1.types
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception".
+overgeneral-exceptions=Exception

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-    - "3.4"
-    - "3.5"
+    - "3.5.3"
     - "3.6"
     - "3.7"
+    - "3.8"
 install: 
     - "pip install -e .[test]"
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-    - "2.7"
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
 install: 
     - "pip install -e .[test]"
 script: 

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ install_requires = [
 ]
 if os.environ.get('READTHEDOCS') != 'True':
     install_requires.append('certifi>=2018.1.18')
-tests_require = [
-    'responses>=0.5.1', 'mock>=2.0.0', 'coverage>=4.2', 'pytest>=3.0.3',
+TESTS_REQUIRE = [
+    'responses>=0.5.1', 'coverage>=4.2', 'pytest>=3.0.3',
     'pytest-cov>=2.3.1,<2.6'
 ]
 
@@ -28,9 +28,9 @@ setup(
     license='MIT',
     author='Ifedapo Olarewaju',
     install_requires=install_requires,
-    tests_require=tests_require,
+    tests_require=TESTS_REQUIRE,
     extras_require={
-        'test': tests_require,
+        'test': TESTS_REQUIRE,
         'dev': ['tox>=2.3.1', 'sphinx-autobuild==0.7.1', 'Sphinx==1.7.1']
     },
     author_email='ifedapoolarewaju@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import tusclient
 
 
 install_requires = [
-    'future>=0.16.0', 'requests>=2.18.4', 'six>=1.11.0', 'tinydb>=3.5.0'
+    'future>=0.16.0', 'requests>=2.18.4', 'six>=1.11.0', 'tinydb>=3.5.0', 'aiohttp>=3.6.2'
 ]
 if os.environ.get('READTHEDOCS') != 'True':
     install_requires.append('certifi>=2018.1.18')
@@ -38,7 +38,7 @@ setup(
     'A Python client for the tus resumable upload protocol ->  http://tus.io',
     long_description=(long_description),
     long_description_content_type='text/markdown',
-    packages=['tusclient', 'tusclient.fingerprint', 'tusclient.storage'],
+    packages=['tusclient', 'tusclient.fingerprint', 'tusclient.storage', 'tusclient.uploader'],
     include_package_data=True,
     platforms='any',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 if os.environ.get('READTHEDOCS') != 'True':
     install_requires.append('certifi>=2018.1.18')
 TESTS_REQUIRE = [
-    'responses>=0.5.1', 'coverage>=4.2', 'pytest>=3.0.3',
+    'responses>=0.5.1', 'aioresponses>=0.6.2', 'coverage>=4.2', 'pytest>=3.0.3',
     'pytest-cov>=2.3.1,<2.6'
 ]
 

--- a/tests/mixin.py
+++ b/tests/mixin.py
@@ -9,7 +9,7 @@ class Mixin(unittest.TestCase):
     @responses.activate
     def setUp(self):
         self.client = client.TusClient('http://master.tus.io/files/')
-        url = 'http://master.tus.io/files/15acd89eabdf5738ffc'
-        responses.add(responses.HEAD, url,
+        self.url = 'http://master.tus.io/files/15acd89eabdf5738ffc'
+        responses.add(responses.HEAD, self.url,
                       adding_headers={"upload-offset": "0"})
-        self.uploader = self.client.uploader('./LICENSE', url=url)
+        self.uploader = self.client.uploader('./LICENSE', url=self.url)

--- a/tests/test_async_uploader.py
+++ b/tests/test_async_uploader.py
@@ -31,7 +31,7 @@ class AsyncUploaderTest(unittest.TestCase):
             self.assertEqual(expected_content, body)
 
         response_headers = {
-            'upload-offset': str(self.async_uploader.offset + self.async_uploader.request_length)}
+            'upload-offset': str(self.async_uploader.offset + self.async_uploader.get_request_length())}
 
         return CallbackResult(status=204, headers=response_headers)
 
@@ -39,7 +39,7 @@ class AsyncUploaderTest(unittest.TestCase):
         with aioresponses() as resps:
             resps.patch(self.url, callback=self._validate_request)
 
-            request_length = self.async_uploader.request_length
+            request_length = self.async_uploader.get_request_length()
             self.loop.run_until_complete(self.async_uploader.upload_chunk())
             self.assertEqual(self.async_uploader.offset, request_length)
 
@@ -49,7 +49,7 @@ class AsyncUploaderTest(unittest.TestCase):
 
             self.loop.run_until_complete(self.async_uploader.upload())
             self.assertEqual(self.async_uploader.offset,
-                             self.async_uploader.file_size)
+                             self.async_uploader.get_file_size())
 
     def test_upload_retry(self):
         num_of_retries = 3

--- a/tests/test_async_uploader.py
+++ b/tests/test_async_uploader.py
@@ -1,0 +1,66 @@
+import unittest
+from unittest import mock
+import asyncio
+
+from aioresponses import aioresponses, CallbackResult
+import responses
+import pytest
+
+from tusclient import exceptions, client
+
+
+class AsyncUploaderTest(unittest.TestCase):
+    @responses.activate
+    def setUp(self):
+        self.client = client.TusClient('http://master.tus.io/files/')
+        self.url = 'http://master.tus.io/files/15acd89eabdf5738ffc'
+        responses.add(responses.HEAD, self.url,
+                      adding_headers={"upload-offset": "0"})
+        self.loop = asyncio.new_event_loop()
+        self.async_uploader = self.client.async_uploader(
+            './LICENSE', url=self.url, io_loop=self.loop)
+
+    def _validate_request(self, url, **kwargs):
+        self.assertEqual(self.url, str(url))
+        req_headers = kwargs['headers']
+        self.assertEqual(req_headers.get('Tus-Resumable'), '1.0.0')
+
+        body = kwargs['data']
+        with open('./LICENSE', 'rb') as stream:
+            expected_content = stream.read()
+            self.assertEqual(expected_content, body)
+
+        response_headers = {
+            'upload-offset': str(self.async_uploader.offset + self.async_uploader.request_length)}
+
+        return CallbackResult(status=204, headers=response_headers)
+
+    def test_upload_chunk(self):
+        with aioresponses() as resps:
+            resps.patch(self.url, callback=self._validate_request)
+
+            request_length = self.async_uploader.request_length
+            self.loop.run_until_complete(self.async_uploader.upload_chunk())
+            self.assertEqual(self.async_uploader.offset, request_length)
+
+    def test_upload(self):
+        with aioresponses() as resps:
+            resps.patch(self.url, callback=self._validate_request)
+
+            self.loop.run_until_complete(self.async_uploader.upload())
+            self.assertEqual(self.async_uploader.offset,
+                             self.async_uploader.file_size)
+
+    def test_upload_retry(self):
+        num_of_retries = 3
+        self.async_uploader.retries = num_of_retries
+        self.async_uploader.retry_delay = 3
+        with aioresponses() as resps:
+            resps.patch(self.url, status=00)
+
+            self.assertEqual(self.async_uploader._retried, 0)
+            with pytest.raises(exceptions.TusCommunicationError):
+                self.loop.run_until_complete(
+                    self.async_uploader.upload_chunk())
+
+            self.assertEqual(self.async_uploader._retried, num_of_retries)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,7 @@ import unittest
 import responses
 
 from tusclient import client
-from tusclient.uploader import Uploader
+from tusclient.uploader import Uploader, AsyncUploader
 
 
 class TusClientTest(unittest.TestCase):
@@ -33,3 +33,14 @@ class TusClientTest(unittest.TestCase):
 
         self.assertIsInstance(uploader, Uploader)
         self.assertEqual(uploader.client, self.client)
+
+    @responses.activate
+    def test_async_uploader(self):
+        url = 'http://master.tus.io/files/15acd89eabdf5738ffc'
+        responses.add(responses.HEAD, url,
+                      adding_headers={"upload-offset": "0"})
+
+        async_uploader = self.client.async_uploader('./LICENSE', url=url)
+
+        self.assertIsInstance(async_uploader, AsyncUploader)
+        self.assertEqual(async_uploader.client, self.client)

--- a/tests/test_filestorage.py
+++ b/tests/test_filestorage.py
@@ -8,7 +8,7 @@ class FileStorageTest(unittest.TestCase):
     def setUp(self):
         self.storage_path = 'storage.json'
         self.storage = filestorage.FileStorage(self.storage_path)
-    
+
     def tearDown(self):
         os.remove(self.storage_path)
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -14,7 +14,7 @@ class TusRequestTest(mixin.Mixin):
 
     def test_perform(self):
         with open('LICENSE', 'rb') as stream, responses.RequestsMock() as resps:
-            size: int = stream.tell()
+            size = stream.tell()
             resps.add(responses.PATCH, self.url,
                       adding_headers={'upload-offset': f'{size}'},
                       status=204)

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -20,7 +20,7 @@ class TusRequestTest(mixin.Mixin):
                       status=204)
 
             self.request.perform()
-            self.assertEqual(f'{size}', self.request.response_headers['upload-offset'])
+            self.assertEqual(str(size), self.request.response_headers['upload-offset'])
 
     def test_perform_checksum(self):
         self.uploader.upload_checksum = True

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,8 +1,10 @@
-import mock
 import base64
 import hashlib
 
-from tusclient import client, request
+import mock
+import requests_mock
+
+from tusclient import request
 from tests import mixin
 
 
@@ -25,27 +27,22 @@ class TusRequestTest(mixin.Mixin):
                 'http://master.tus.io/files/15acd89eabdf5738ffc',
                 data=f.read(), headers=headers)
 
-    def test_perform_checksum(self):
+    @requests_mock.Mocker()
+    def test_perform_checksum(self, mocked_request):
         self.uploader.upload_checksum = True
-        self.request_checksum = request.TusRequest(self.uploader)
-        with mock.patch.object(self.request_checksum, 'handle') as mock_:
-            self.request_checksum.handle = mock_
-            self.request_checksum.perform()
-        with open('LICENSE', 'rb') as f:
-            license = f.read()
+        tus_request = request.TusRequest(self.uploader)
+
+        with open('LICENSE', 'r') as f:
+            license_ = f.read()
             headers = {
                 'upload-offset': '0',
                 'Content-Type': 'application/offset+octet-stream'
             }
+            encoded_file = license_.encode('utf-8')
             headers.update(self.uploader.headers)
             headers["upload-checksum"] = "sha1 " + \
-                base64.standard_b64encode(hashlib.sha1(license).digest()).decode("ascii")
-            mock_.patch.assert_called_with(
+                base64.standard_b64encode(hashlib.sha1(encoded_file).digest()).decode("ascii")
+            mocked_request.patch(
                 'http://master.tus.io/files/15acd89eabdf5738ffc',
-                data=license, headers=headers)
-
-    def test_close(self):
-        with mock.patch.object(self.request, 'handle') as mock_:
-            self.request.handle = mock_
-            self.request.close()
-        mock_.close.assert_called_with()
+                text=license_, request_headers=headers)
+            tus_request.perform()

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -16,7 +16,7 @@ class TusRequestTest(mixin.Mixin):
         with open('LICENSE', 'rb') as stream, responses.RequestsMock() as resps:
             size = stream.tell()
             resps.add(responses.PATCH, self.url,
-                      adding_headers={'upload-offset': f'{size}'},
+                      adding_headers={'upload-offset': str(size)},
                       status=204)
 
             self.request.perform()

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -16,7 +16,7 @@ class UploaderTest(mixin.Mixin):
         request_mock = request_mock.return_value
         request_mock.status_code = 204
         request_mock.response_headers = {
-            'upload-offset': self.uploader.offset + self.uploader.request_length}
+            'upload-offset': self.uploader.offset + self.uploader.get_request_length()}
         request_mock.perform.return_value = None
         return request_mock
 
@@ -26,10 +26,10 @@ class UploaderTest(mixin.Mixin):
         self.assertEqual(self.uploader.offset, 0)
 
     def test_headers(self):
-        self.assertEqual(self.uploader.headers, {"Tus-Resumable": "1.0.0"})
+        self.assertEqual(self.uploader.get_headers(), {"Tus-Resumable": "1.0.0"})
 
         self.client.set_headers({'foo': 'bar'})
-        self.assertEqual(self.uploader.headers, {"Tus-Resumable": "1.0.0", 'foo': 'bar'})
+        self.assertEqual(self.uploader.get_headers(), {"Tus-Resumable": "1.0.0", 'foo': 'bar'})
 
     @responses.activate
     def test_get_offset(self):
@@ -60,26 +60,23 @@ class UploaderTest(mixin.Mixin):
         self.assertEqual(self.uploader.create_url(), 'http://master.tus.io/files/foo')
 
     @responses.activate 
-    def test_get_url(self):
-        responses.add(responses.POST, self.client.url,
-                      adding_headers={"location": 'http://master.tus.io/files/foo'})
-        self.assertEqual(self.uploader.get_url(), 'http://master.tus.io/files/foo')
-
+    def test_url(self):
         # test for stored urls
         responses.add(responses.HEAD, 'http://master.tus.io/files/foo_bar',
-                      adding_headers={"upload-offset": "0"})
+                      adding_headers={"upload-offset": "10"})
         storage_path = '{}/storage_file'.format(os.path.dirname(os.path.abspath(__file__)))
         resumable_uploader = self.client.uploader(
             file_path='./LICENSE', store_url=True, url_storage=filestorage.FileStorage(storage_path)
         )
-        self.assertEqual(resumable_uploader.get_url(), 'http://master.tus.io/files/foo_bar')
+        self.assertEqual(resumable_uploader.url, 'http://master.tus.io/files/foo_bar')
+        self.assertEqual(resumable_uploader.offset, 10)
 
     def test_request_length(self):
         self.uploader.chunk_size = 200
-        self.assertEqual(self.uploader.request_length, 200)
+        self.assertEqual(self.uploader.get_request_length(), 200)
 
-        self.uploader.chunk_size = self.uploader.file_size + 3000
-        self.assertEqual(self.uploader.request_length, self.uploader.file_size)
+        self.uploader.chunk_size = self.uploader.get_file_size() + 3000
+        self.assertEqual(self.uploader.get_request_length(), self.uploader.get_file_size())
 
     def test_get_file_stream(self):
         with open('./LICENSE', 'rb') as fs:
@@ -93,19 +90,19 @@ class UploaderTest(mixin.Mixin):
             self.assertEqual(fs.read(), self.uploader.get_file_stream().read())
 
     def test_file_size(self):
-        self.assertEqual(self.uploader.file_size, os.path.getsize(self.uploader.file_path))
+        self.assertEqual(self.uploader.get_file_size(), os.path.getsize(self.uploader.file_path))
 
         with open('./AUTHORS', 'rb') as fs:
             self.uploader.file_stream = fs
             self.uploader.file_path = None
-            self.assertEqual(self.uploader.file_size, os.path.getsize('./AUTHORS'))
+            self.assertEqual(self.uploader.get_file_size(), os.path.getsize('./AUTHORS'))
 
     @mock.patch('tusclient.uploader.uploader.TusRequest')
     def test_upload_chunk(self, request_mock):
         self.mock_request(request_mock)
 
         self.uploader.offset = 0
-        request_length = self.uploader.request_length
+        request_length = self.uploader.get_request_length()
         self.uploader.upload_chunk()
         self.assertEqual(self.uploader.offset, request_length)
 
@@ -114,7 +111,7 @@ class UploaderTest(mixin.Mixin):
         self.mock_request(request_mock)
 
         self.uploader.upload()
-        self.assertEqual(self.uploader.offset, self.uploader.file_size)
+        self.assertEqual(self.uploader.offset, self.uploader.get_file_size())
 
     @mock.patch('tusclient.uploader.uploader.TusRequest')
     def test_upload_retry(self, request_mock):
@@ -135,4 +132,4 @@ class UploaderTest(mixin.Mixin):
         self.mock_request(request_mock)
         self.uploader.upload_checksum = True
         self.uploader.upload()
-        self.assertEqual(self.uploader.offset, self.uploader.file_size)
+        self.assertEqual(self.uploader.offset, self.uploader.get_file_size())

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -1,10 +1,9 @@
 import os
 from base64 import b64encode
+from unittest import mock
 
-import six
 import responses
 import pytest
-import mock
 
 from tusclient import exceptions
 from tusclient.storage import filestorage
@@ -13,7 +12,7 @@ from tests import mixin
 
 class UploaderTest(mixin.Mixin):
 
-    def mock_pycurl(self, request_mock):
+    def mock_request(self, request_mock):
         request_mock = request_mock.return_value
         request_mock.status_code = 204
         request_mock.response_headers = {
@@ -42,7 +41,7 @@ class UploaderTest(mixin.Mixin):
         self.uploader.metadata = {'foo': 'bar', 'red': 'blue'}
         encoded_metadata = ['foo' + ' ' + b64encode(b'bar').decode('ascii'),
                             'red' + ' ' + b64encode(b'blue').decode('ascii')]
-        six.assertCountEqual(self, self.uploader.encode_metadata(), encoded_metadata)
+        self.assertCountEqual(self.uploader.encode_metadata(), encoded_metadata)
 
         with pytest.raises(ValueError):
             self.uploader.metadata = {'foo, ': 'bar'}
@@ -103,7 +102,7 @@ class UploaderTest(mixin.Mixin):
 
     @mock.patch('tusclient.uploader.uploader.TusRequest')
     def test_upload_chunk(self, request_mock):
-        self.mock_pycurl(request_mock)
+        self.mock_request(request_mock)
 
         self.uploader.offset = 0
         request_length = self.uploader.request_length
@@ -112,7 +111,7 @@ class UploaderTest(mixin.Mixin):
 
     @mock.patch('tusclient.uploader.uploader.TusRequest')
     def test_upload(self, request_mock):
-        self.mock_pycurl(request_mock)
+        self.mock_request(request_mock)
 
         self.uploader.upload()
         self.assertEqual(self.uploader.offset, self.uploader.file_size)
@@ -123,7 +122,7 @@ class UploaderTest(mixin.Mixin):
         self.uploader.retries = num_of_retries
         self.uploader.retry_delay = 3
 
-        request_mock = self.mock_pycurl(request_mock)
+        request_mock = self.mock_request(request_mock)
         request_mock.status_code = 00
 
         self.assertEqual(self.uploader._retried, 0)
@@ -133,7 +132,7 @@ class UploaderTest(mixin.Mixin):
     
     @mock.patch('tusclient.uploader.uploader.TusRequest')
     def test_upload_checksum(self, request_mock):
-        self.mock_pycurl(request_mock)
+        self.mock_request(request_mock)
         self.uploader.upload_checksum = True
         self.uploader.upload()
         self.assertEqual(self.uploader.offset, self.uploader.file_size)

--- a/tusclient/client.py
+++ b/tusclient/client.py
@@ -23,8 +23,8 @@ class TusClient:
     """
 
     def __init__(self, url: str, headers: Optional[Dict[str, str]] = None):
-        self.url: str = url
-        self.headers: Dict[str, str] = headers or {}
+        self.url = url
+        self.headers = headers or {}
 
     def set_headers(self, headers: Dict[str, str]):
         """

--- a/tusclient/client.py
+++ b/tusclient/client.py
@@ -1,7 +1,9 @@
-from tusclient.uploader import Uploader
+from typing import Dict, Optional
+
+from tusclient.uploader import Uploader, AsyncUploader
 
 
-class TusClient(object):
+class TusClient:
     """
     Object representation of Tus client.
 
@@ -20,12 +22,11 @@ class TusClient(object):
         - headers (Optiional[dict])
     """
 
-    def __init__(self, url, headers=None):
-        self.url = url
-        self.headers = headers or {}
+    def __init__(self, url: str, headers: Optional[Dict[str, str]] = None):
+        self.url: str = url
+        self.headers: Dict[str, str] = headers or {}
 
-    # you can set authentication headers with this.
-    def set_headers(self, headers):
+    def set_headers(self, headers: Dict[str, str]):
         """
         Set tus client headers.
 
@@ -38,7 +39,7 @@ class TusClient(object):
         """
         self.headers.update(headers)
 
-    def uploader(self, *args, **kwargs):
+    def uploader(self, *args, **kwargs) -> Uploader:
         """
         Return uploader instance pointing at current client instance.
 
@@ -50,3 +51,7 @@ class TusClient(object):
         """
         kwargs['client'] = self
         return Uploader(*args, **kwargs)
+
+    def async_uploader(self, *args, **kwargs) -> AsyncUploader:
+        kwargs['client'] = self
+        return AsyncUploader(*args, **kwargs)

--- a/tusclient/exceptions.py
+++ b/tusclient/exceptions.py
@@ -30,4 +30,3 @@ class TusCommunicationError(Exception):
 
 class TusUploadFailed(TusCommunicationError):
     """Should be raised when an attempted upload fails"""
-    pass

--- a/tusclient/fingerprint/fingerprint.py
+++ b/tusclient/fingerprint/fingerprint.py
@@ -2,9 +2,8 @@
 An implementation of of <tusclient.figerprint.interface.Figerprint>,
 using the hashlib to generate an md5 hash based on the file content
 """
+from typing import IO
 import hashlib
-
-from six import b
 
 from . import interface
 
@@ -12,25 +11,25 @@ from . import interface
 class Fingerprint(interface.Fingerprint):
     BLOCK_SIZE = 65536
 
-    def get_fingerprint(self, fs):
+    def get_fingerprint(self, fs: IO):
         """
         Return a unique fingerprint string value based on the file stream recevied
 
         :Args:
-            - fs[file]: The file stream instance of the file for which a fingerprint would be generated.
+            - fs[IO]: The file stream instance of the file for which a fingerprint would be generated.
         :Returns: fingerprint[str]
         """
         hasher = hashlib.md5()
         # we encode the content to avoid python 3 uncicode errors
         buf = self._encode_data(fs.read(self.BLOCK_SIZE))
-        while len(buf) > 0:
+        while buf:
             hasher.update(buf)
             buf = fs.read(self.BLOCK_SIZE)
         return 'md5:' + hasher.hexdigest()
 
     def _encode_data(self, data):
         try:
-            return b(data)
+            return data.encode('utf-8')
         except AttributeError:
             # in case the content is already binary, this failure would happen.
             return data

--- a/tusclient/fingerprint/interface.py
+++ b/tusclient/fingerprint/interface.py
@@ -1,19 +1,19 @@
 """
 Interface module defining a fingerprint generator based on file content.
 """
+from typing import IO
 import abc
-import six
 
 
-@six.add_metaclass(abc.ABCMeta)
-class Fingerprint(object):
+class Fingerprint(abc.ABC):
+    """An interface specifying the requirements of a file fingerprint"""
+
     @abc.abstractmethod
-    def get_fingerprint(self, fs):
+    def get_fingerprint(self, fs: IO):
         """
         Return a unique fingerprint string value based on the file stream recevied
 
         :Args:
-            - fs[file]: The file stream instance of the file for which a fingerprint would be generated.
+            - fs[IO]: The file stream instance of the file for which a fingerprint would be generated.
         :Returns: fingerprint[str]
         """
-        pass

--- a/tusclient/request.py
+++ b/tusclient/request.py
@@ -73,7 +73,7 @@ class TusRequest(BaseTusRequest):
         Perform actual request.
         """
         try:
-            chunk: bytes = self.file.read(self._content_length)
+            chunk = self.file.read(self._content_length)
             self.add_checksum(chunk)
             resp = requests.patch(self._url, data=chunk,
                                   headers=self._request_headers)
@@ -95,7 +95,7 @@ class AsyncTusRequest(BaseTusRequest):
         """
         Perform actual request.
         """
-        chunk: bytes = self.file.read(self._content_length)
+        chunk = self.file.read(self._content_length)
         self.add_checksum(chunk)
         try:
             async with aiohttp.ClientSession(loop=self.io_loop) as session:

--- a/tusclient/storage/filestorage.py
+++ b/tusclient/storage/filestorage.py
@@ -11,7 +11,7 @@ class FileStorage(interface.Storage):
         self._db = TinyDB(fp)
         self._urls = Query()
 
-    def get_item(self, key):
+    def get_item(self, key: str):
         """
         Return the tus url of a file, identified by the key specified.
 
@@ -22,7 +22,7 @@ class FileStorage(interface.Storage):
         result = self._db.search(self._urls.key == key)
         return result[0].get('url') if result else None
 
-    def set_item(self, key, url):
+    def set_item(self, key: str, url: str):
         """
         Store the url value under the unique key.
 
@@ -35,7 +35,7 @@ class FileStorage(interface.Storage):
         else:
             self._db.insert({'key': key, 'url': url})
 
-    def remove_item(self, key):
+    def remove_item(self, key: str):
         """
         Remove/Delete the url value under the unique key from storage.
         """

--- a/tusclient/uploader/__init__.py
+++ b/tusclient/uploader/__init__.py
@@ -1,0 +1,1 @@
+from tusclient.uploader.uploader import AsyncUploader, Uploader

--- a/tusclient/uploader/baseuploader.py
+++ b/tusclient/uploader/baseuploader.py
@@ -121,7 +121,7 @@ class BaseUploader:
         self.__init_url_and_offset(url)
         self.chunk_size = chunk_size
         self.retries = retries
-        self.request: Optional[TusRequest] = None
+        self.request = None
         self._retried = 0
         self.retry_delay = retry_delay
         self.upload_checksum = upload_checksum

--- a/tusclient/uploader/uploader.py
+++ b/tusclient/uploader/uploader.py
@@ -103,7 +103,7 @@ class AsyncUploader(BaseUploader):
 
     async def _retry_or_cry(self, error):
         if self.retries > self._retried:
-            asyncio.sleep(self.retry_delay, loop=self.io_loop)
+            await asyncio.sleep(self.retry_delay, loop=self.io_loop)
 
             self._retried += 1
             try:

--- a/tusclient/uploader/uploader.py
+++ b/tusclient/uploader/uploader.py
@@ -1,0 +1,116 @@
+from typing import Optional
+import time
+import asyncio
+
+from tusclient.uploader.baseuploader import BaseUploader
+
+from tusclient.exceptions import TusUploadFailed, TusCommunicationError
+from tusclient.request import TusRequest, AsyncTusRequest
+
+
+def _verify_upload(request: TusRequest):
+    if request.status_code == 204:
+        return True
+    else:
+        raise TusUploadFailed('', request.status_code, request.response_content)
+
+
+class Uploader(BaseUploader):
+    def upload(self, stop_at: Optional[int] = None):
+        """
+        Perform file upload.
+
+        Performs continous upload of chunks of the file. The size uploaded at each cycle is
+        the value of the attribute 'chunk_size'.
+
+        :Args:
+            - stop_at (Optional[int]):
+                Determines at what offset value the upload should stop. If not specified this
+                defaults to the file size.
+        """
+        self.stop_at = stop_at or self.file_size
+
+        while self.offset < self.stop_at:
+            self.upload_chunk()
+
+    def upload_chunk(self):
+        """
+        Upload chunk of file.
+        """
+        self._retried = 0
+        self._do_request()
+        self.offset = int(self.request.response_headers.get('upload-offset'))
+
+    def _do_request(self):
+        self.request = TusRequest(self)
+        try:
+            self.request.perform()
+            _verify_upload(self.request)
+        except TusUploadFailed as error:
+            self._retry_or_cry(error)
+
+    def _retry_or_cry(self, error):
+        if self.retries > self._retried:
+            time.sleep(self.retry_delay)
+
+            self._retried += 1
+            try:
+                self.offset = self.get_offset()
+            except TusCommunicationError as e:
+                self._retry_or_cry(e)
+            else:
+                self._do_request()
+        else:
+            raise error
+
+
+class AsyncUploader(BaseUploader):
+    def __init__(self, *args, io_loop: Optional[asyncio.AbstractEventLoop] = None, **kwargs):
+        self.io_loop = io_loop
+        super().__init__(*args, **kwargs)
+
+    async def upload(self, stop_at: Optional[int] = None):
+        """
+        Perform file upload.
+
+        Performs continous upload of chunks of the file. The size uploaded at each cycle is
+        the value of the attribute 'chunk_size'.
+
+        :Args:
+            - stop_at (Optional[int]):
+                Determines at what offset value the upload should stop. If not specified this
+                defaults to the file size.
+        """
+        self.stop_at = stop_at or self.file_size
+        while self.offset < self.stop_at:
+            await self.upload_chunk()
+
+    async def upload_chunk(self):
+        """
+        Upload chunk of file.
+        """
+        self._retried = 0
+        await self._do_request()
+        self.offset = int(self.request.response_headers.get('upload-offset'))
+
+    async def _do_request(self):
+        self.request = AsyncTusRequest(self)
+        try:
+            await self.request.perform()
+            _verify_upload(self.request)
+        except TusUploadFailed as error:
+            await self._retry_or_cry(error)
+
+    async def _retry_or_cry(self, error):
+        if self.retries > self._retried:
+            asyncio.sleep(self.retry_delay, loop=self.io_loop)
+
+            self._retried += 1
+            try:
+                self.offset = self.get_offset()
+            except TusCommunicationError as err:
+                await self._retry_or_cry(err)
+            else:
+                await self._do_request()
+        else:
+            raise error


### PR DESCRIPTION
This PR drops Python 2 support in order to support python3 asyncIO functionalities.
 It introduces the `AsyncUploader` which can be used for async uploads, while the synchronous `Uploader` also remains available. Proper documentation of these changes will be added in a follow up PR.