### PR TITLE
Only do first block of the file for a finger print [Matches javascrip…

### DIFF
--- a/tests/storage_file
+++ b/tests/storage_file
@@ -1,1 +1,1 @@
-{"_default": {"1": {"url": "http://master.tus.io/files/foo_bar", "key": "md5:f3e5fa051d458fb7f22eaf03749c8272"}}}
+{"_default": {"1": {"url": "http://master.tus.io/files/foo_bar", "key": "size:1078--md5:f3e5fa051d458fb7f22eaf03749c8272"}}}

--- a/tusclient/fingerprint/fingerprint.py
+++ b/tusclient/fingerprint/fingerprint.py
@@ -27,7 +27,7 @@ class Fingerprint(interface.Fingerprint):
         # add in the file size to minimize chances of collision
         fs.seek(0, os.SEEK_END)
         file_size = fs.tell()
-        hasher.update(str(file_size))
+        hasher.update(str(file_size).encode())
         return 'md5:' + hasher.hexdigest()
 
     def _encode_data(self, data):

--- a/tusclient/fingerprint/fingerprint.py
+++ b/tusclient/fingerprint/fingerprint.py
@@ -27,7 +27,7 @@ class Fingerprint(interface.Fingerprint):
         # add in the file size to minimize chances of collision
         fs.seek(0, os.SEEK_END)
         file_size = fs.tell()
-        hasher.update(f"{file_size}")
+        hasher.update(str(file_size))
         return 'md5:' + hasher.hexdigest()
 
     def _encode_data(self, data):

--- a/tusclient/fingerprint/fingerprint.py
+++ b/tusclient/fingerprint/fingerprint.py
@@ -4,6 +4,7 @@ using the hashlib to generate an md5 hash based on the file content
 """
 from typing import IO
 import hashlib
+import os
 
 from . import interface
 
@@ -23,6 +24,10 @@ class Fingerprint(interface.Fingerprint):
         # we encode the content to avoid python 3 uncicode errors
         buf = self._encode_data(fs.read(self.BLOCK_SIZE))
         hasher.update(buf)
+        # add in the file size to minimize chances of collision
+        fs.seek(0, os.SEEK_END)
+        file_size = fs.tell()
+        hasher.update(f"{file_size}")
         return 'md5:' + hasher.hexdigest()
 
     def _encode_data(self, data):

--- a/tusclient/fingerprint/fingerprint.py
+++ b/tusclient/fingerprint/fingerprint.py
@@ -27,8 +27,7 @@ class Fingerprint(interface.Fingerprint):
         # add in the file size to minimize chances of collision
         fs.seek(0, os.SEEK_END)
         file_size = fs.tell()
-        hasher.update(str(file_size).encode())
-        return 'md5:' + hasher.hexdigest()
+        return f'size:{file_size}--md5:{hasher.hexdigest()}'
 
     def _encode_data(self, data):
         try:

--- a/tusclient/fingerprint/fingerprint.py
+++ b/tusclient/fingerprint/fingerprint.py
@@ -22,9 +22,7 @@ class Fingerprint(interface.Fingerprint):
         hasher = hashlib.md5()
         # we encode the content to avoid python 3 uncicode errors
         buf = self._encode_data(fs.read(self.BLOCK_SIZE))
-        while buf:
-            hasher.update(buf)
-            buf = fs.read(self.BLOCK_SIZE)
+        hasher.update(buf)
         return 'md5:' + hasher.hexdigest()
 
     def _encode_data(self, data):

--- a/tusclient/fingerprint/fingerprint.py
+++ b/tusclient/fingerprint/fingerprint.py
@@ -27,7 +27,7 @@ class Fingerprint(interface.Fingerprint):
         # add in the file size to minimize chances of collision
         fs.seek(0, os.SEEK_END)
         file_size = fs.tell()
-        return f'size:{file_size}--md5:{hasher.hexdigest()}'
+        return 'size:{}--md5:{}'.format(file_size, hasher.hexdigest())
 
     def _encode_data(self, data):
         try:


### PR DESCRIPTION
For generating a fingerprint, the javascript client only does an md5_sum of the minimum of the block size or file size; not the entire file. This PR would mirror the python to this behavior.

https://github.com/tus/tus-js-client/blob/13383e8178635d432d585ab13326b2de223a452f/lib/node/fingerprint.js#L15
