### PR TITLE
fix: allow all 2XX status code for an upload response

### DIFF
--- a/tusclient/uploader/uploader.py
+++ b/tusclient/uploader/uploader.py
@@ -13,7 +13,7 @@ from tusclient.request import TusRequest, AsyncTusRequest, catch_requests_error
 
 
 def _verify_upload(request: TusRequest):
-    if request.status_code == 204:
+    if 200 <= request.status_code < 300:
         return True
     else:
         raise TusUploadFailed('', request.status_code,


### PR DESCRIPTION
This commit is to align with the behavior of tus-js-client. See:
https://github.com/tus/tus-js-client/blob/ba50a8a2c629584273c52dcd133759709ad5e261/lib/upload.js#L693

Although TUS protocol says "The Server MUST acknowledge successful PATCH requests with the 204 No Content status." [1], I think accepting all 2XX status codes doesn't harm anything. Being a client it's better to be more compatible with servers in the wild.

And in my use case, as a backend developer, I'd like to respond 200 with some information so that my client could check the up-to-date info ASAP.

References:
1. https://tus.io/protocols/resumable-upload.html#patch