### PR TITLE
upload using a ChunkReader

### DIFF
--- a/tests/test_async_uploader.py
+++ b/tests/test_async_uploader.py
@@ -20,12 +20,15 @@ class AsyncUploaderTest(unittest.TestCase):
         self.async_uploader = self.client.async_uploader(
             './LICENSE', url=self.url, io_loop=self.loop)
 
-    def _validate_request(self, url, **kwargs):
+    async def _validate_request(self, url, **kwargs):
         self.assertEqual(self.url, str(url))
         req_headers = kwargs['headers']
         self.assertEqual(req_headers.get('Tus-Resumable'), '1.0.0')
 
-        body = kwargs['data']
+        generator = kwargs['data']
+        body = b''
+        async for chunk in generator:
+            body += chunk
         with open('./LICENSE', 'rb') as stream:
             expected_content = stream.read()
             self.assertEqual(expected_content, body)

--- a/tusclient/request.py
+++ b/tusclient/request.py
@@ -42,40 +42,49 @@ class BaseTusRequest:
         self.response_headers = {}
         self.status_code = None
         self.response_content = None
-        self.file = uploader.get_file_stream()
-        self.file.seek(uploader.offset)
 
         self._request_headers = {
             'upload-offset': str(uploader.offset),
             'Content-Type': 'application/offset+octet-stream'
         }
         self._request_headers.update(uploader.get_headers())
-        self._content_length = uploader.get_request_length()
         self._upload_checksum = uploader.upload_checksum
         self._checksum_algorithm = uploader.checksum_algorithm
         self._checksum_algorithm_name = uploader.checksum_algorithm_name
 
-    def add_checksum(self, chunk: bytes):
-        if self._upload_checksum:
-            self._request_headers['upload-checksum'] = \
-                ' '.join((
-                    self._checksum_algorithm_name,
-                    base64.b64encode(
-                        self._checksum_algorithm(chunk).digest()
-                    ).decode('ascii'),
-                ))
+        self._chunk = ChunkReader(
+            uploader.get_file_stream(),
+            uploader.offset,
+            uploader.get_request_length(),
+        )
+
+    def add_checksum(self, file):
+        checksum = self._checksum_algorithm()
+        chunk = file.read(8192)
+        while chunk:
+            checksum.update(chunk)
+            chunk = file.read(8192)
+
+        self._request_headers['upload-checksum'] = \
+            ' '.join((
+                self._checksum_algorithm_name,
+                base64.b64encode(
+                    checksum.digest()
+                ).decode('ascii'),
+            ))
 
 
 class TusRequest(BaseTusRequest):
     """Class to handle async Tus upload requests"""
+
     def perform(self):
         """
         Perform actual request.
         """
+        if self._upload_checksum:
+            self.add_checksum(self._chunk.reset())
         try:
-            chunk = self.file.read(self._content_length)
-            self.add_checksum(chunk)
-            resp = requests.patch(self._url, data=chunk,
+            resp = requests.patch(self._url, data=self._chunk.reset(),
                                   headers=self._request_headers)
             self.status_code = resp.status_code
             self.response_content = resp.content
@@ -87,6 +96,7 @@ class TusRequest(BaseTusRequest):
 
 class AsyncTusRequest(BaseTusRequest):
     """Class to handle async Tus upload requests"""
+
     def __init__(self, *args, io_loop: Optional[asyncio.AbstractEventLoop] = None, **kwargs):
         self.io_loop = io_loop
         super().__init__(*args, **kwargs)
@@ -95,14 +105,43 @@ class AsyncTusRequest(BaseTusRequest):
         """
         Perform actual request.
         """
-        chunk = self.file.read(self._content_length)
-        self.add_checksum(chunk)
+        if self._upload_checksum:
+            self.add_checksum(self._chunk.reset())
         try:
             async with aiohttp.ClientSession(loop=self.io_loop) as session:
-                async with session.patch(self._url, data=chunk, headers=self._request_headers) as resp:
+                async with session.patch(self._url, data=self._chunk.reset().async_reader(8*1024), headers=self._request_headers) as resp:
                     self.status_code = resp.status
                     self.response_headers = {
                         k.lower(): v for k, v in resp.headers.items()}
                     self.response_content = await resp.content.read()
         except aiohttp.ClientError as error:
             raise TusUploadFailed(error)
+
+
+class ChunkReader(object):
+    def __init__(self, file, start, length):
+        self.file = file
+        self.start = start
+        self.len = length  # to send Content-Length in headers
+        self.remaining = None
+
+    def reset(self):
+        self.file.seek(self.start)
+        self.remaining = self.len
+        return self
+
+    def read(self, size=-1):
+        if self.remaining is None:
+            raise Exception("reset() must be called before first read")
+
+        if size == -1 or size > self.remaining:
+            size = self.remaining
+        data = self.file.read(size)
+        self.remaining -= len(data)
+        return data
+
+    async def async_reader(self, size=-1):
+        chunk = self.read(size)
+        while chunk:
+            yield chunk
+            chunk = self.read(size)


### PR DESCRIPTION
This PR prevents the uploaded file from being completely loaded in memory.
Instead it will be read chunk-by-chunk.

This can be particularly useful to upload files larger than the available RAM.

My implementation of a `ChunkReader` can probably be improved, thanks in advance for the feedback!