### PR TITLE
Make metadata encoding configurable

### DIFF
--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -47,6 +47,15 @@ class UploaderTest(mixin.Mixin):
             self.uploader.metadata = {'foo, ': 'bar'}
             self.uploader.encode_metadata()
 
+    def test_encode_metadata_utf8(self):
+        self.uploader.metadata = {'foo': 'bär', 'red': '🔵'}
+        self.uploader.metadata_encoding = 'utf-8'
+        encoded_metadata = [
+            'foo ' + b64encode('bär'.encode('utf-8')).decode('ascii'),
+            'red ' + b64encode('🔵'.encode('utf-8')).decode('ascii')
+        ]
+        self.assertCountEqual(self.uploader.encode_metadata(), encoded_metadata)
+
     @responses.activate
     def test_create_url_absolute(self):
         responses.add(responses.POST, self.client.url,

--- a/tusclient/uploader/baseuploader.py
+++ b/tusclient/uploader/baseuploader.py
@@ -42,6 +42,8 @@ class BaseUploader:
         - metadata (dict):
             A dictionary containing the upload-metadata. This would be encoded internally
             by the method `encode_metadata` to conform with the tus protocol.
+        - metadata_encoding (str):
+            Encoding used for each upload-metadata value. This defaults to 'latin-1'.
         - offset (int):
             The offset value of the upload indicates the current position of the file upload.
         - stop_at (int):
@@ -76,6 +78,7 @@ class BaseUploader:
         - client (Optional [<tusclient.client.TusClient>])
         - chunk_size (Optional[int])
         - metadata (Optional[dict])
+        - metadata_encoding (Optional[str])
         - retries (Optional[int])
         - retry_delay (Optional[int])
         - store_url (Optional[bool])
@@ -90,6 +93,7 @@ class BaseUploader:
     def __init__(self, file_path: Optional[str] = None, file_stream: Optional[IO] = None,
                  url: Optional[str] = None, client: Optional['TusClient'] = None,
                  chunk_size: int = MAXSIZE, metadata: Optional[Dict] = None,
+                 metadata_encoding: Optional[str] = 'latin-1',
                  retries: int = 0, retry_delay: int = 30,
                  store_url=False, url_storage: Optional[Storage] = None,
                  fingerprinter: Optional[interface.Fingerprint] = None,
@@ -110,6 +114,7 @@ class BaseUploader:
         self.stop_at = self.get_file_size()
         self.client = client
         self.metadata = metadata or {}
+        self.metadata_encoding = metadata_encoding
         self.store_url = store_url
         self.url_storage = url_storage
         self.fingerprinter = fingerprinter or fingerprint.Fingerprint()
@@ -182,7 +187,7 @@ class BaseUploader:
                 msg = 'Upload-metadata key "{}" cannot be empty nor contain spaces or commas.'
                 raise ValueError(msg.format(key_str))
 
-            value_bytes = value.encode('latin-1')
+            value_bytes = value.encode(self.metadata_encoding)
             encoded_list.append('{} {}'.format(
                 key_str, b64encode(value_bytes).decode('ascii')))
         return encoded_list

--- a/tusclient/uploader/baseuploader.py
+++ b/tusclient/uploader/baseuploader.py
@@ -43,7 +43,7 @@ class BaseUploader:
             A dictionary containing the upload-metadata. This would be encoded internally
             by the method `encode_metadata` to conform with the tus protocol.
         - metadata_encoding (str):
-            Encoding used for each upload-metadata value. This defaults to 'latin-1'.
+            Encoding used for each upload-metadata value. This defaults to 'utf-8'.
         - offset (int):
             The offset value of the upload indicates the current position of the file upload.
         - stop_at (int):
@@ -93,7 +93,7 @@ class BaseUploader:
     def __init__(self, file_path: Optional[str] = None, file_stream: Optional[IO] = None,
                  url: Optional[str] = None, client: Optional['TusClient'] = None,
                  chunk_size: int = MAXSIZE, metadata: Optional[Dict] = None,
-                 metadata_encoding: Optional[str] = 'latin-1',
+                 metadata_encoding: Optional[str] = 'utf-8',
                  retries: int = 0, retry_delay: int = 30,
                  store_url=False, url_storage: Optional[Storage] = None,
                  fingerprinter: Optional[interface.Fingerprint] = None,


### PR DESCRIPTION
tus-py-client has defaulted to 'latin-1' encoding due to the six
compatibility library using the same encoding by default when encoding
strings to bytes. The same encoding has been maintained although six is
no longer used for byte string handling.

Make the encoding configurable by adding a `metadata_encoding` keyword
argument to `TusClient.uploader`. The encoding is set to `latin-1` by
default to maintain backwards compatibility, although `utf-8` is
preferred because it matches the encoding used by `tus-js-client`,
another reference tus-py client.

Fixes #38

---

I opted to make the default metadata encoding `latin-1` since that's been used by tus-py until now. However, tus-js-client uses `utf-8` instead, so making that the default would make sense as well. What do you think?