### PR TITLE
Make certificate validation configurable

### DIFF
--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -42,3 +42,20 @@ class TusRequestTest(mixin.Mixin):
             resps.add_callback(responses.PATCH, self.url, callback=validate_headers)
             tus_request.perform()
             self.assertEqual(sent_checksum, expected_checksum)
+
+    def test_verify_tls_cert(self):
+        self.uploader.verify_tls_cert = False
+        tus_request = request.TusRequest(self.uploader)
+
+        with responses.RequestsMock() as resps:
+            verify = None
+
+            def validate_verify(req):
+                nonlocal verify
+                verify = req.req_kwargs['verify']
+                return (204, {}, None)
+
+            resps.add_callback(responses.PATCH, self.url, callback=validate_verify)
+            tus_request.perform()
+            self.assertEqual(verify, False)
+

--- a/tusclient/uploader/baseuploader.py
+++ b/tusclient/uploader/baseuploader.py
@@ -54,6 +54,9 @@ class BaseUploader:
         - retry_delay (int):
             How long (in seconds) the uploader should wait before retrying a failed upload attempt.
             If not specified, it defaults to 30.
+        - verify_tls_cert (bool):
+            Whether or not to verify the TLS certificate of the server.
+            If not specified, it defaults to True.
         - store_url (bool):
             Determines whether or not url should be stored, and uploads should be resumed.
         - url_storage (<tusclient.storage.interface.Storage>):
@@ -78,6 +81,7 @@ class BaseUploader:
         - metadata (Optional[dict])
         - retries (Optional[int])
         - retry_delay (Optional[int])
+        - verify_tls_cert (Optional[bool])
         - store_url (Optional[bool])
         - url_storage (Optinal [<tusclient.storage.interface.Storage>])
         - fingerprinter (Optional [<tusclient.fingerprint.interface.Fingerprint>])
@@ -91,7 +95,8 @@ class BaseUploader:
                  url: Optional[str] = None, client: Optional['TusClient'] = None,
                  chunk_size: int = MAXSIZE, metadata: Optional[Dict] = None,
                  retries: int = 0, retry_delay: int = 30,
-                 store_url=False, url_storage: Optional[Storage] = None,
+                 verify_tls_cert: bool = True, store_url=False,
+                 url_storage: Optional[Storage] = None,
                  fingerprinter: Optional[interface.Fingerprint] = None,
                  upload_checksum=False):
         if file_path is None and file_stream is None:
@@ -117,6 +122,7 @@ class BaseUploader:
         self.url = None
         self.__init_url_and_offset(url)
         self.chunk_size = chunk_size
+        self.verify_tls_cert = verify_tls_cert
         self.retries = retries
         self.request = None
         self._retried = 0

--- a/tusclient/uploader/uploader.py
+++ b/tusclient/uploader/uploader.py
@@ -57,7 +57,8 @@ class Uploader(BaseUploader):
         Makes request to tus server to create a new upload url for the required file upload.
         """
         resp = requests.post(
-            self.client.url, headers=self.get_url_creation_headers())
+            self.client.url, headers=self.get_url_creation_headers(),
+            verify=self.verify_tls_cert)
         url = resp.headers.get("location")
         if url is None:
             msg = 'Attempt to retrieve create file url with status {}'.format(
@@ -128,7 +129,9 @@ class AsyncUploader(BaseUploader):
         try:
             async with aiohttp.ClientSession() as session:
                 headers = self.get_url_creation_headers()
-                async with session.post(self.client.url, headers=headers) as resp:
+                ssl = None if self.verify_tls_cert else False
+                async with session.post(
+                        self.client.url, headers=headers, ssl=ssl) as resp:
                     url = resp.headers.get("location")
                     if url is None:
                         msg = 'Attempt to retrieve create file url with status {}'.format(


### PR DESCRIPTION
Disabling TLS certificate validation can be necessary in some
environments (eg. testing). Add a `verify` keyword argument that allows
the verification to be disabled.

The current implementation only accepts a boolean argument. Both
requests and aiohttp allow defining a custom CA bundle, which can be
implemented later if needed.

Fixes #30