### PR TITLE
Fix Python 3.10 support and async uploader exception

### DIFF
--- a/tests/test_async_uploader.py
+++ b/tests/test_async_uploader.py
@@ -18,7 +18,7 @@ class AsyncUploaderTest(unittest.TestCase):
                       adding_headers={"upload-offset": "0"})
         self.loop = asyncio.new_event_loop()
         self.async_uploader = self.client.async_uploader(
-            './LICENSE', url=self.url, io_loop=self.loop)
+            './LICENSE', url=self.url)
 
     def _validate_request(self, url, **kwargs):
         self.assertEqual(self.url, str(url))

--- a/tusclient/uploader/uploader.py
+++ b/tusclient/uploader/uploader.py
@@ -89,8 +89,7 @@ class Uploader(BaseUploader):
 
 
 class AsyncUploader(BaseUploader):
-    def __init__(self, *args, io_loop: Optional[asyncio.AbstractEventLoop] = None, **kwargs):
-        self.io_loop = io_loop
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     async def upload(self, stop_at: Optional[int] = None):
@@ -127,7 +126,7 @@ class AsyncUploader(BaseUploader):
         Makes request to tus server to create a new upload url for the required file upload.
         """
         try:
-            async with aiohttp.ClientSession(loop=self.io_loop) as session:
+            async with aiohttp.ClientSession() as session:
                 headers = self.get_url_creation_headers()
                 async with session.post(self.client.url, headers=headers) as resp:
                     url = resp.headers.get("location")
@@ -149,7 +148,7 @@ class AsyncUploader(BaseUploader):
 
     async def _retry_or_cry(self, error):
         if self.retries > self._retried:
-            await asyncio.sleep(self.retry_delay, loop=self.io_loop)
+            await asyncio.sleep(self.retry_delay)
 
             self._retried += 1
             try:

--- a/tusclient/uploader/uploader.py
+++ b/tusclient/uploader/uploader.py
@@ -132,7 +132,7 @@ class AsyncUploader(BaseUploader):
                     url = resp.headers.get("location")
                     if url is None:
                         msg = 'Attempt to retrieve create file url with status {}'.format(
-                            resp.status_code)
+                            resp.status)
                         raise TusCommunicationError(msg, resp.status, await resp.content.read())
                     return urljoin(self.client.url, url)
         except aiohttp.ClientError as error:


### PR DESCRIPTION
Fix Python 3.10 by removing the usage of deprecated `loop` keyword argument, which has been unnecessary since Python 3.6. This project appears to support only Python 3.8 and up, so this should be a safe change with no change in behavior.

Also fix `TusCommunicationError` exception that wasn't raised properly due to the error handler referencing a non-existent property.