### PR TITLE
Remore unnecessary future install requirement

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,14 +19,14 @@ sys.path.insert(0, os.path.abspath('../../'))
 
 # -- Project information -----------------------------------------------------
 
-project = u'tuspy'
-copyright = u'2018, Ifedapo Olarewaju'
-author = u'Ifedapo Olarewaju'
+project = 'tuspy'
+copyright = '2018, Ifedapo Olarewaju'
+author = 'Ifedapo Olarewaju'
 
 # The short X.Y version
-version = u''
+version = ''
 # The full version, including alpha/beta/rc tags
-release = u''
+release = ''
 
 
 # -- General configuration ---------------------------------------------------
@@ -127,8 +127,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'tuspy.tex', u'tuspy Documentation',
-     u'Ifedapo Olarewaju', 'manual'),
+    (master_doc, 'tuspy.tex', 'tuspy Documentation',
+     'Ifedapo Olarewaju', 'manual'),
 ]
 
 
@@ -137,7 +137,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'tuspy', u'tuspy Documentation',
+    (master_doc, 'tuspy', 'tuspy Documentation',
      [author], 1)
 ]
 
@@ -148,7 +148,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'tuspy', u'tuspy Documentation',
+    (master_doc, 'tuspy', 'tuspy Documentation',
      author, 'tuspy', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/setup.py
+++ b/setup.py
@@ -46,4 +46,6 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Internet :: File Transfer Protocol (FTP)',
         'Topic :: Communications :: File Sharing',
-    ])
+    ],
+    python_requires=">=3.5.3",
+)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-import sys
-import os
 from setuptools import setup
 
 import tusclient
@@ -11,7 +9,6 @@ setup(
     license='MIT',
     author='Ifedapo Olarewaju',
     install_requires=[
-        'future>=0.16.0',
         'requests>=2.18.4',
         'six>=1.11.0',
         'tinydb>=3.5.0',
@@ -32,8 +29,7 @@ setup(
         ]
     },
     author_email='ifedapoolarewaju@gmail.com',
-    description=
-    'A Python client for the tus resumable upload protocol ->  http://tus.io',
+    description='A Python client for the tus resumable upload protocol ->  http://tus.io',
     long_description=open('README.md', encoding='utf-8').read(),
     long_description_content_type='text/markdown',
     packages=['tusclient', 'tusclient.fingerprint', 'tusclient.storage', 'tusclient.uploader'],

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 
 import six


### PR DESCRIPTION
Also:
- Specify minimum Python version as derived from aiohttp 3.6.2 .
- Small clean up of Python2 relics.