### PR TITLE
Add support for `creation-defer-length` extension

### DIFF
--- a/tusclient/request.py
+++ b/tusclient/request.py
@@ -40,9 +40,10 @@ class BaseTusRequest:
 
     def __init__(self, uploader):
         self._url = uploader.url
-        self.response_headers = {}
         self.status_code = None
+        self.response_headers = {}
         self.response_content = None
+        self.stream_eof = False
         self.verify_tls_cert = bool(uploader.verify_tls_cert)
         self.file = uploader.get_file_stream()
         self.file.seek(uploader.offset)
@@ -51,8 +52,8 @@ class BaseTusRequest:
             "upload-offset": str(uploader.offset),
             "Content-Type": "application/offset+octet-stream",
         }
-        if not uploader.length_declared:
-            self._request_headers["upload-length"] = str(uploader.file_size)
+        self._offset = uploader.offset
+        self._upload_length_deferred = uploader.upload_length_deferred
         self._request_headers.update(uploader.get_headers())
         self._content_length = uploader.get_request_length()
         self._upload_checksum = uploader.upload_checksum
@@ -80,16 +81,21 @@ class TusRequest(BaseTusRequest):
         """
         try:
             chunk = self.file.read(self._content_length)
+            stream_eof = len(chunk) < self._content_length
             self.add_checksum(chunk)
+            headers = self._request_headers
+            if stream_eof and self._upload_length_deferred:
+                headers["upload-length"] = str(self._offset + len(chunk))
             resp = requests.patch(
                 self._url,
                 data=chunk,
-                headers=self._request_headers,
+                headers=headers,
                 verify=self.verify_tls_cert,
             )
             self.status_code = resp.status_code
             self.response_content = resp.content
             self.response_headers = {k.lower(): v for k, v in resp.headers.items()}
+            self.stream_eof = stream_eof
         except requests.exceptions.RequestException as error:
             raise TusUploadFailed(error)
 

--- a/tusclient/request.py
+++ b/tusclient/request.py
@@ -51,6 +51,8 @@ class BaseTusRequest:
             "upload-offset": str(uploader.offset),
             "Content-Type": "application/offset+octet-stream",
         }
+        if not uploader.length_declared:
+            self._request_headers["upload-length"] = str(uploader.file_size)
         self._request_headers.update(uploader.get_headers())
         self._content_length = uploader.get_request_length()
         self._upload_checksum = uploader.upload_checksum

--- a/tusclient/uploader/baseuploader.py
+++ b/tusclient/uploader/baseuploader.py
@@ -208,7 +208,7 @@ class BaseUploader:
     @catch_requests_error
     def declare_length(self):
         """
-        Declare length to tus server and returns whether it was actually declared.
+        Declare length to tus server and return whether it was actually declared.
         
         Makes empty patch request with Upload-Length header in order to declare length.
         """
@@ -217,6 +217,8 @@ class BaseUploader:
         )
         resp.raise_for_status()
         if resp.headers.get('Upload-Defer-Length') == '1':
+            if self.file_size is None:
+                self.file_size = self.get_file_size()
             headers = {
                 "upload-offset": str(self.offset),
                 "upload-length": str(self.file_size),
@@ -229,9 +231,8 @@ class BaseUploader:
                 verify=self.verify_tls_cert,
             )
             resp.raise_for_status()
-            self.length_declared = True
+            self.upload_length_deferred = False
             return True
-        self.length_declared = True
         return False
 
     def encode_metadata(self):

--- a/tusclient/uploader/baseuploader.py
+++ b/tusclient/uploader/baseuploader.py
@@ -74,7 +74,9 @@ class BaseUploader:
             Whether or not to supply the Upload-Checksum header along with each
             chunk. Defaults to False.
         - upload_length_deferred (bool):
-            Wherher or not to declare length only when finished reading the given file stream.
+            Whether or not to declare the upload length when finished reading the file stream instead of when the upload is started. This is useful
+            when uploading from a streaming resource, where the total file size isn't available when the upload is created
+            but only becomes known when the stream finishes. The server must support the `creation-defer-length` extension.
 
     :Constructor Args:
         - file_path (str)

--- a/tusclient/uploader/baseuploader.py
+++ b/tusclient/uploader/baseuploader.py
@@ -207,36 +207,6 @@ class BaseUploader:
             raise TusCommunicationError(msg, resp.status_code, resp.content)
         return int(offset)
 
-    @catch_requests_error
-    def declare_length(self):
-        """
-        Declare length to tus server and return whether it was actually declared.
-        
-        Makes empty patch request with Upload-Length header in order to declare length.
-        """
-        resp = requests.head(
-            self.url, headers=self.get_headers(), verify=self.verify_tls_cert
-        )
-        resp.raise_for_status()
-        if resp.headers.get('Upload-Defer-Length') == '1':
-            if self.file_size is None:
-                self.file_size = self.get_file_size()
-            headers = {
-                "upload-offset": str(self.offset),
-                "upload-length": str(self.file_size),
-                "Content-Type": "application/offset+octet-stream",
-            }
-            headers.update(self.get_headers())
-            resp = requests.patch(
-                self.url,
-                headers=headers,
-                verify=self.verify_tls_cert,
-            )
-            resp.raise_for_status()
-            self.upload_length_deferred = False
-            return True
-        return False
-
     def encode_metadata(self):
         """
         Return list of encoded metadata as defined by the Tus protocol.


### PR DESCRIPTION
Currently, there is no way to declare length to tus server unless it has been declared on upload start (POST request).
So when upload was started somewhere else with "Upload-Defer-Length": "1" header it becomes impossible to continue upload using python client since it will never send "Upload-Length" header to the server.

I attempt to solve it by adding `declare_length` method to `Uploader` class that will first HEAD upload_url and if "Upload-Defer-Length": "1" is returned then send empty PATCH request with "Upload-Length" header. Orecautions are needed since [the second and subsequent length declarations raise an error](https://github.com/tus/tusd/blob/806f27d5d74a8a620940f07ad0fe5a38e5f53407/pkg/handler/unrouted_handler.go#L773).
I also tried to make it efficient as possible and added `length_declared` keyword argument to `BaseUploader` that is True by default and can be set to False in order to hint that length should be declared as soon as possible and it will be declared on next PATCH request. I agree, that the code is a bit of a mess, but I haven't found a better way to implement this crucial feature so far.

I also investigated other approaches. For example, I found out that ["Upload-Complete" IETF header can be used](https://github.com/tus/tusd/blob/806f27d5d74a8a620940f07ad0fe5a38e5f53407/pkg/handler/unrouted_handler.go#L1383) in order to hint server to finish upload even though length wasn't declared, but I decided that it's a bad idea to mess tus client with IETF headers.

I think that in the future it would be great to support uploading byte stream without seeking to the end to determine its size and declare its size only when last read operation happened and eof occured.

Looking forward to your to your opinion on this issue and its solution @Acconut 

